### PR TITLE
Add missing deploy command in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ extra:
 Make a change to `docs/index.md`, and publish the first version:
 
 ```
-mike --push --update-aliases 0.1 latest
+mike deploy --push --update-aliases 0.1 latest
 ```
 
 Set the default version to `latest`
@@ -48,5 +48,5 @@ mike set-default --push latest
 Now, make another change and publish a new version:
 
 ```
-mike --push --update-aliases 0.2 latest
+mike deploy --push --update-aliases 0.2 latest
 ```


### PR DESCRIPTION
Documentation is missing the deploy command. Adding the `deploy` command to keep it consistent.
